### PR TITLE
Clean up CLRF delimited stream

### DIFF
--- a/src/crlf_delimited_stream.rs
+++ b/src/crlf_delimited_stream.rs
@@ -1,19 +1,6 @@
-use std::io;
+use std::{io, mem};
 use futures::stream::Stream;
 use futures::{Poll, Async};
-
-fn last_two<T>(v: &Vec<T>) -> Option<Vec<T>> where T: Copy {
-    if v.len() >= 2 {
-        Some(vec!(v[v.len()-2], v[v.len()-1]))
-    } else {
-        None
-    }
-}
-
-fn ends_with_carriage_return_line_feed(v: &Vec<u8>) -> bool {
-    v[v.len()-2] == b'\r' && v[v.len()-1] == b'\n'
-}
-
 
 pub type BoxedReadStream = Box<Stream<Item=u8, Error=io::Error>>;
 
@@ -36,38 +23,15 @@ impl Stream for CarriageReturnLineFeedDelimitedStream {
     type Error=io::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        loop {
-            let poll = self.stream.poll();
-            match poll {
-                Ok(Async::Ready(Some(x))) => {
-                    println!("have value: {}", x);
-                    self.build.push(x);
-                    match last_two(&self.build) {
-                        Some(_) => {
-                            if ends_with_carriage_return_line_feed(&self.build) {
-                                let b = Box::new(self.build.to_vec());
-                                self.build.clear();
-                                return Ok(Async::Ready(Some(b)))
-                            }
-                        },
-                        None => {},
-                    }
-
-                },
-                Ok(Async::Ready(None)) => {
-                    println!("have no value");
-                    return Ok(Async::NotReady)
-                }
-                Ok(Async::NotReady) => {
-                    println!("have not ready");
-                    return Ok(Async::NotReady)
-                },
-                Err(e) => {
-                    println!("e: {:?}", e);
-                    return Err(e)
-                }
+        while !self.build.ends_with(b"\r\n") {
+            match try!(self.stream.poll()) {
+                Async::Ready(Some(byte)) => self.build.push(byte),
+                Async::NotReady | Async::Ready(None) => return Ok(Async::NotReady),
             }
         }
+        let mut result = Vec::new();
+        mem::swap(&mut result, &mut self.build);
+        Ok(Async::Ready(Some(Box::new(result))))
     }
 }
 


### PR DESCRIPTION
Changed to take advantage of `ends_with` and used `mem::swap` to return
the vec that was built during iteration rather than copying and then
clearing. I've also cleaned up the pattern matching. The debug lines
were removed, as they can be handled at the call site if they are
needed. The only case that loses information is `Ok(Ready(None))`, but
as discussed elsewhere that case is actually signalling EOF so it should
be refactored out
